### PR TITLE
add mkfile module. add manual status mode in shell/scrpit/command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tachyon
 tachyon-linux-amd64
 scratch/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ install:
   - mkdir ~/go
   - go get -d -v ./... && go build -v ./...
 go:
-  - 1.2
+  - 1.4.1
+  - tip
 script: sudo GOPATH=$GOPATH PATH=$PATH `which go` test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+OS = darwin freebsd linux openbsd
+ARCHS = 386 amd64 arm
+
+all: build release
+
+build: deps
+	go build
+
+release: clean deps
+	@for arch in $(ARCHS);\
+	do \
+		for os in $(OS);\
+		do \
+			echo "Building $$os-$$arch"; \
+			mkdir -p build/tachyon-$$os-$$arch/; \
+			GOOS=$$os GOARCH=$$arch go build -o build/tachyon-$$os-$$arch/tachyon; \
+			tar cz -C build -f build/tachyon-$$os-$$arch.tar.gz tachyon-$$os-$$arch; \
+		done \
+	done
+
+test: deps
+	go test ./...
+
+deps:
+	go get -d -v -t ./...
+
+clean:
+	rm -rf build
+	rm -f tachyon

--- a/builtin.go
+++ b/builtin.go
@@ -6,14 +6,18 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"github.com/flynn/go-shlex"
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
+
+	"github.com/flynn/go-shlex"
 )
 
 func captureCmd(c *exec.Cmd, show bool) ([]byte, []byte, error) {
@@ -109,8 +113,12 @@ func RunCommand(env *CommandEnv, parts ...string) (*CommandResult, error) {
 
 	stdout, stderr, err := captureCmd(c, env.Env.config.ShowCommandOutput)
 	if err != nil {
-		if _, ok := err.(*exec.ExitError); ok {
-			rc = 1
+		if e2, ok := err.(*exec.ExitError); ok {
+			if s, ok := e2.Sys().(syscall.WaitStatus); ok {
+				rc = s.ExitStatus()
+			} else {
+				return nil, fmt.Errorf("Unimplemented for system where exec.ExitError.Sys() is not syscall.WaitStatus.,err:%s", err)
+			}
 		} else {
 			return nil, err
 		}
@@ -131,8 +139,12 @@ func RunCommandInEnv(env *CommandEnv, unixEnv []string, parts ...string) (*Comma
 
 	stdout, stderr, err := captureCmd(c, env.Env.config.ShowCommandOutput)
 	if err != nil {
-		if _, ok := err.(*exec.ExitError); ok {
-			rc = 1
+		if e2, ok := err.(*exec.ExitError); ok {
+			if s, ok := e2.Sys().(syscall.WaitStatus); ok {
+				rc = s.ExitStatus()
+			} else {
+				return nil, fmt.Errorf("Unimplemented for system where exec.ExitError.Sys() is not syscall.WaitStatus.,err:%s", err)
+			}
 		} else {
 			return nil, err
 		}
@@ -141,29 +153,71 @@ func RunCommandInEnv(env *CommandEnv, unixEnv []string, parts ...string) (*Comma
 	return &CommandResult{rc, stdout, stderr}, nil
 }
 
-func runCmd(env *CommandEnv, ignore bool, parts ...string) (*Result, error) {
-	cmd, err := RunCommand(env, parts...)
-	if !ignore && err != nil {
-		return nil, err
+type runCmdParam struct {
+	IgnoreFail    bool
+	IgnoreChanged bool
+	ManualStatus  bool
+	ChangedRc     int
+	OkRc          int
+	ChangedCreate string
+}
+
+func runCmd(env *CommandEnv, cmd runCmdParam, parts ...string) (*Result, error) {
+	res, err := RunCommand(env, parts...)
+	if res == nil && err != nil {
+		return FailureResult(err), err
 	}
-
-	r := NewResult(true)
-
-	r.Add("rc", cmd.ReturnCode)
-	r.Add("stdout", strings.TrimSpace(string(cmd.Stdout)))
-	r.Add("stderr", strings.TrimSpace(string(cmd.Stderr)))
+	r := NewResult(!cmd.IgnoreChanged)
+	r.Add("rc", res.ReturnCode)
+	r.Add("stdout", strings.TrimSpace(string(res.Stdout)))
+	r.Add("stderr", strings.TrimSpace(string(res.Stderr)))
 
 	if str, ok := renderShellResult(r); ok {
 		r.Add("_result", str)
 	}
 
+	if cmd.ManualStatus {
+		switch {
+		case cmd.ChangedRc == res.ReturnCode:
+			r.Changed = true
+		case cmd.OkRc == res.ReturnCode:
+			r.Changed = false
+		default:
+			return FailureResult(err), err
+		}
+		return r, nil
+	}
+	if !cmd.IgnoreFail && err != nil {
+		return nil, err
+	}
+	r.Changed = !cmd.IgnoreChanged
+	if res.ReturnCode != 0 {
+		r.Failed = true
+		if !cmd.IgnoreFail {
+			return r, fmt.Errorf("Return code:%d, stderr:%s", res.ReturnCode, res.Stderr)
+		}
+	} else if r.Changed && cmd.ChangedCreate != "" {
+		cf, err := os.Create(cmd.ChangedCreate)
+		if err != nil {
+			return FailureResult(err), err
+		}
+		defer cf.Close()
+		if _, err = fmt.Fprintf(cf, "%s result:%# v", time.Now(), r); err != nil {
+			return FailureResult(err), err
+		}
+	}
 	return r, nil
 }
 
 type CommandCmd struct {
-	Command    string `tachyon:"command,required"`
-	Creates    string `tachyon:"creates"`
-	IgnoreFail bool   `tachyon:"ignore_failure"`
+	Command       string `tachyon:"command,required"`
+	Creates       string `tachyon:"creates"`
+	IgnoreFail    bool   `tachyon:"ignore_failure"`
+	IgnoreChanged bool   `tachyon:"ignore_changed"`
+	ManualStatus  bool   `tachyon:"manual_status"`
+	OkRc          int    `tachyon:"ok_rc"`
+	ChangedRc     int    `tachyon:"changed_rc"`
+	ChangedCreate string `tachyon:"changed_create"`
 }
 
 func (cmd *CommandCmd) Run(env *CommandEnv) (*Result, error) {
@@ -180,10 +234,18 @@ func (cmd *CommandCmd) Run(env *CommandEnv) (*Result, error) {
 	parts, err := shlex.Split(cmd.Command)
 
 	if err != nil {
-		return nil, err
+		return FailureResult(err), err
 	}
 
-	return runCmd(env, cmd.IgnoreFail, parts...)
+	param := runCmdParam{
+		IgnoreFail:    cmd.IgnoreFail,
+		IgnoreChanged: cmd.IgnoreChanged,
+		ManualStatus:  cmd.ManualStatus,
+		ChangedRc:     cmd.ChangedRc,
+		OkRc:          cmd.OkRc,
+		ChangedCreate: cmd.ChangedCreate,
+	}
+	return runCmd(env, param, parts...)
 }
 
 func (cmd *CommandCmd) ParseArgs(s Scope, args string) (Vars, error) {
@@ -195,9 +257,14 @@ func (cmd *CommandCmd) ParseArgs(s Scope, args string) (Vars, error) {
 }
 
 type ShellCmd struct {
-	Command    string `tachyon:"command,required"`
-	Creates    string `tachyon:"creates"`
-	IgnoreFail bool   `tachyon:"ignore_failure"`
+	Command       string `tachyon:"command,required"`
+	Creates       string `tachyon:"creates"`
+	IgnoreFail    bool   `tachyon:"ignore_failure"`
+	IgnoreChanged bool   `tachyon:"ignore_changed"`
+	ManualStatus  bool   `tachyon:"manual_status"`
+	OkRc          int    `tachyon:"ok_rc"`
+	ChangedRc     int    `tachyon:"changed_rc"`
+	ChangedCreate string `tachyon:"changed_create"`
 }
 
 func (cmd *ShellCmd) Run(env *CommandEnv) (*Result, error) {
@@ -211,7 +278,15 @@ func (cmd *ShellCmd) Run(env *CommandEnv) (*Result, error) {
 		}
 	}
 
-	return runCmd(env, cmd.IgnoreFail, "sh", "-c", cmd.Command)
+	param := runCmdParam{
+		IgnoreFail:    cmd.IgnoreFail,
+		IgnoreChanged: cmd.IgnoreChanged,
+		ManualStatus:  cmd.ManualStatus,
+		ChangedRc:     cmd.ChangedRc,
+		OkRc:          cmd.OkRc,
+		ChangedCreate: cmd.ChangedCreate,
+	}
+	return runCmd(env, param, "sh", "-c", cmd.Command)
 }
 
 func (cmd *ShellCmd) ParseArgs(s Scope, args string) (Vars, error) {
@@ -243,7 +318,7 @@ func renderShellResult(res *Result) (string, bool) {
 	stderr := stderrv.Read().(string)
 
 	if rc == 0 && len(stdout) == 0 && len(stderr) == 0 {
-		return "", true
+		return "OK", true
 	} else if len(stderr) == 0 && len(stdout) < 60 {
 		stdout = strings.Replace(stdout, "\n", " ", -1)
 		return fmt.Sprintf(`rc: %d, stdout: "%s"`, rc, stdout), true
@@ -252,11 +327,11 @@ func renderShellResult(res *Result) (string, bool) {
 	return "", false
 }
 
-type CopyCmd struct {
-	Src  string `tachyon:"src,required"`
-	Dest string `tachyon:"dest,required"`
+func md5string(s string) []byte {
+	h := md5.New()
+	io.WriteString(h, s)
+	return h.Sum(nil)
 }
-
 func md5file(path string) ([]byte, error) {
 	h := md5.New()
 
@@ -264,12 +339,115 @@ func md5file(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer i.Close()
 
 	if _, err := io.Copy(h, i); err != nil {
 		return nil, err
 	}
 
 	return h.Sum(nil), nil
+}
+
+type MkFileCmd struct {
+	Src   string `tachyon:"src,required"`
+	Dest  string `tachyon:"dest,required"`
+	Owner string `tachyon:"owner"`
+	Uid   int    `tachyon:"uid"`
+	Gid   int    `tachyon:"gid"`
+	Mode  int    `tachyon:"mode"`
+}
+
+func (cmd *MkFileCmd) Run(env *CommandEnv) (*Result, error) {
+	srcDigest := md5string(cmd.Src)
+	var dstDigest []byte
+
+	dest := cmd.Dest
+
+	link := false
+
+	destStat, err := os.Lstat(dest)
+	if err == nil {
+		dstDigest, _ = md5file(dest)
+		link = destStat.Mode()&os.ModeSymlink != 0
+	}
+
+	rd := ResultData{
+		"md5sum": Any(hex.EncodeToString(srcDigest)),
+		"src":    Any(cmd.Src),
+		"dest":   Any(dest),
+	}
+
+	if dstDigest != nil && bytes.Equal(srcDigest, dstDigest) {
+		changed := false
+
+		if cmd.Mode != 0 && destStat.Mode() != os.FileMode(cmd.Mode) {
+			changed = true
+			if err := os.Chmod(dest, os.FileMode(cmd.Mode)); err != nil {
+				return FailureResult(err), err
+			}
+		}
+		if cmd.Uid, cmd.Gid, err = ChangePerm(cmd.Owner, cmd.Uid, cmd.Gid); err != nil {
+			return FailureResult(err), err
+		}
+		if estat, ok := destStat.Sys().(*syscall.Stat_t); ok {
+			if cmd.Uid != int(estat.Uid) || cmd.Gid != int(estat.Gid) {
+				changed = true
+				os.Chown(dest, cmd.Uid, cmd.Gid)
+			}
+		}
+
+		return WrapResult(changed, rd), nil
+	}
+
+	tmp := fmt.Sprintf("%s.tmp.%d", cmd.Dest, os.Getpid())
+
+	output, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY, 0644)
+
+	if err != nil {
+		return FailureResult(err), err
+	}
+
+	defer output.Close()
+
+	if _, err = output.Write([]byte(cmd.Src)); err != nil {
+		os.Remove(tmp)
+		return FailureResult(err), err
+	}
+
+	if link {
+		os.Remove(dest)
+	}
+
+	if cmd.Mode != 0 {
+		if err := os.Chmod(tmp, os.FileMode(cmd.Mode)); err != nil {
+			os.Remove(tmp)
+			return FailureResult(err), err
+		}
+	}
+
+	if cmd.Mode != 0 {
+		if cmd.Uid, cmd.Gid, err = ChangePerm(cmd.Owner, cmd.Uid, cmd.Gid); err != nil {
+			return FailureResult(err), err
+		}
+	}
+	os.Chown(tmp, cmd.Uid, cmd.Gid)
+
+	err = os.Rename(tmp, dest)
+	if err != nil {
+		os.Remove(tmp)
+		return FailureResult(err), err
+	}
+
+	return WrapResult(true, rd), nil
+}
+
+type CopyCmd struct {
+	Src   string `tachyon:"src,required"`
+	Dest  string `tachyon:"dest,required"`
+	Owner string `tachyon:"owner"`
+	Uid   int    `tachyon:"uid"`
+	Gid   int    `tachyon:"gid"`
+	Mode  int    `tachyon:"mode"`
 }
 
 func (cmd *CopyCmd) Run(env *CommandEnv) (*Result, error) {
@@ -281,25 +459,27 @@ func (cmd *CopyCmd) Run(env *CommandEnv) (*Result, error) {
 		src = env.Paths.File(cmd.Src)
 	}
 
+	if cmd.Mode == 0 {
+		fi, err := os.Stat(src)
+		if err != nil {
+			return FailureResult(err), err
+		}
+		cmd.Mode = int(fi.Mode())
+
+	}
 	input, err := os.Open(src)
 
 	if err != nil {
-		return nil, err
+		return FailureResult(err), err
 	}
-
-	srcStat, err := os.Stat(src)
-	if err != nil {
-		return nil, err
-	}
+	defer input.Close()
 
 	srcDigest, err := md5file(src)
 	if err != nil {
-		return nil, err
+		return FailureResult(err), err
 	}
 
 	var dstDigest []byte
-
-	defer input.Close()
 
 	dest := cmd.Dest
 
@@ -325,19 +505,20 @@ func (cmd *CopyCmd) Run(env *CommandEnv) (*Result, error) {
 	if dstDigest != nil && bytes.Equal(srcDigest, dstDigest) {
 		changed := false
 
-		if destStat.Mode() != srcStat.Mode() {
+		if cmd.Mode != 0 && destStat.Mode() != os.FileMode(cmd.Mode) {
 			changed = true
-			if err := os.Chmod(dest, srcStat.Mode()); err != nil {
-				return nil, err
+			if err := os.Chmod(dest, os.FileMode(cmd.Mode)); err != nil {
+				return FailureResult(err), err
 			}
 		}
 
-		if ostat, ok := srcStat.Sys().(*syscall.Stat_t); ok {
-			if estat, ok := destStat.Sys().(*syscall.Stat_t); ok {
-				if ostat.Uid != estat.Uid || ostat.Gid != estat.Gid {
-					changed = true
-					os.Chown(dest, int(ostat.Uid), int(ostat.Gid))
-				}
+		if cmd.Uid, cmd.Gid, err = ChangePerm(cmd.Owner, cmd.Uid, cmd.Gid); err != nil {
+			return FailureResult(err), err
+		}
+		if estat, ok := destStat.Sys().(*syscall.Stat_t); ok {
+			if cmd.Uid != int(estat.Uid) || cmd.Gid != int(estat.Gid) {
+				changed = true
+				os.Chown(dest, cmd.Uid, cmd.Gid)
 			}
 		}
 
@@ -349,42 +530,48 @@ func (cmd *CopyCmd) Run(env *CommandEnv) (*Result, error) {
 	output, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		return nil, err
+		return FailureResult(err), err
 	}
 
 	defer output.Close()
 
 	if _, err = io.Copy(output, input); err != nil {
 		os.Remove(tmp)
-		return nil, err
+		return FailureResult(err), err
 	}
 
 	if link {
 		os.Remove(dest)
 	}
 
-	if err := os.Chmod(tmp, srcStat.Mode()); err != nil {
+	if err := os.Chmod(tmp, os.FileMode(cmd.Mode)); err != nil {
 		os.Remove(tmp)
-		return nil, err
+		return FailureResult(err), err
 	}
 
-	if ostat, ok := srcStat.Sys().(*syscall.Stat_t); ok {
-		os.Chown(tmp, int(ostat.Uid), int(ostat.Gid))
+	if cmd.Uid, cmd.Gid, err = ChangePerm(cmd.Owner, cmd.Uid, cmd.Gid); err != nil {
+		return FailureResult(err), err
 	}
+	os.Chown(tmp, cmd.Uid, cmd.Gid)
 
 	err = os.Rename(tmp, dest)
 	if err != nil {
 		os.Remove(tmp)
-		return nil, err
+		return FailureResult(err), err
 	}
 
 	return WrapResult(true, rd), nil
 }
 
 type ScriptCmd struct {
-	Script     string `tachyon:"command,required"`
-	Creates    string `tachyon:"creates"`
-	IgnoreFail bool   `tachyon:"ignore_failure"`
+	Script        string `tachyon:"command,required"`
+	Creates       string `tachyon:"creates"`
+	IgnoreFail    bool   `tachyon:"ignore_failure"`
+	IgnoreChanged bool   `tachyon:"ignore_changed"`
+	ManualStatus  bool   `tachyon:"manual_status"`
+	OkRc          int    `tachyon:"ok_rc"`
+	ChangedRc     int    `tachyon:"changed_rc"`
+	ChangedCreate string `tachyon:"changed_create"`
 }
 
 func (cmd *ScriptCmd) ParseArgs(s Scope, args string) (Vars, error) {
@@ -417,17 +604,55 @@ func (cmd *ScriptCmd) Run(env *CommandEnv) (*Result, error) {
 
 	_, err = os.Stat(path)
 	if err != nil {
-		return nil, err
+		return FailureResult(err), err
 	}
 
 	runArgs := append([]string{"sh", path}, parts[1:]...)
 
-	return runCmd(env, cmd.IgnoreFail, runArgs...)
+	param := runCmdParam{
+		IgnoreFail:    cmd.IgnoreFail,
+		IgnoreChanged: cmd.IgnoreChanged,
+		ManualStatus:  cmd.ManualStatus,
+		ChangedRc:     cmd.ChangedRc,
+		OkRc:          cmd.OkRc,
+		ChangedCreate: cmd.ChangedCreate,
+	}
+	return runCmd(env, param, runArgs...)
 }
 
 func init() {
 	RegisterCommand("command", &CommandCmd{})
 	RegisterCommand("shell", &ShellCmd{})
 	RegisterCommand("copy", &CopyCmd{})
+	RegisterCommand("mkfile", &MkFileCmd{})
 	RegisterCommand("script", &ScriptCmd{})
+}
+
+func ChangePerm(owner string, suid, sgid int) (uid, gid int, err error) {
+	var u *user.User
+	switch {
+	case owner != "" && suid != 0:
+		err = fmt.Errorf("both uid and owner is specified. owner:%s,uid:%d", owner, suid)
+		return
+	case owner == "" && suid == 0 && sgid == 0:
+		if u, err = user.Current(); err != nil {
+			return
+		}
+		uid, _ = strconv.Atoi(u.Uid)
+		gid, _ = strconv.Atoi(u.Gid)
+	case owner != "":
+		if u, err = user.Lookup(owner); err != nil {
+			return
+		}
+		uid, _ = strconv.Atoi(u.Uid)
+		if sgid != 0 {
+			gid = sgid
+		} else {
+			gid, _ = strconv.Atoi(u.Gid)
+		}
+	default:
+		uid = suid
+		gid = sgid
+	}
+	return
 }

--- a/cmd/tachyon.go
+++ b/cmd/tachyon.go
@@ -1,18 +1,23 @@
 package main
 
 import (
+	"os"
+
 	"github.com/vektra/tachyon"
 	_ "github.com/vektra/tachyon/net"
 	_ "github.com/vektra/tachyon/package"
 	_ "github.com/vektra/tachyon/procmgmt"
-	"os"
 )
 
 var Release string
+var version string
 
 func main() {
 	if Release != "" {
 		tachyon.Release = Release
+	}
+	if version != "" {
+		tachyon.Version = version
 	}
 
 	os.Exit(tachyon.Main(os.Args))

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@ package tachyon
 
 import (
 	"fmt"
-	"github.com/jessevdk/go-flags"
 	"os"
 	"path/filepath"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type Options struct {
@@ -20,6 +21,7 @@ type Options struct {
 }
 
 var Release string = "dev"
+var Version string = ""
 var Arg0 string
 
 func Main(args []string) int {


### PR DESCRIPTION
- Separation of the expand to ExpandTemplate and ExpandVars @masahide
- Extern script command structure @masahide
- Makefile support cross-building **go 1.4.1/1.5**:
  
  ``` sh
  $ make
  go get -d -v -t ./...
  go build
  rm -rf build
  rm -f tachyon
  Building darwin-386
  Building freebsd-386
  Building linux-386
  Building openbsd-386
  Building darwin-amd64
  Building freebsd-amd64
  Building linux-amd64
  Building openbsd-amd64
  Building darwin-arm
  Building freebsd-arm
  Building linux-arm
  Building openbsd-arm
  
  $ ls build/*.tar.gz
  build/tachyon-darwin-386.tar.gz    build/tachyon-freebsd-amd64.tar.gz build/tachyon-linux-arm.tar.gz
  build/tachyon-darwin-amd64.tar.gz  build/tachyon-freebsd-arm.tar.gz   build/tachyon-openbsd-386.tar.gz
  build/tachyon-darwin-arm.tar.gz    build/tachyon-linux-386.tar.gz     build/tachyon-openbsd-amd64.tar.gz
  build/tachyon-freebsd-386.tar.gz   build/tachyon-linux-amd64.tar.gz   build/tachyon-openbsd-arm.tar.gz
  ```
